### PR TITLE
add location mapping in identify calls

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -8,6 +8,8 @@ var hash = require('string-hash');
 var time = require('unix-time');
 var dot = require('obj-case');
 var is = require('is');
+var countryList = require('countries-list');
+var lookup = require('country-data').lookup;
 
 /**
  * Map identify `msg`.
@@ -31,6 +33,9 @@ exports.identify = function(msg){
   if (msg.ip()) ret.last_seen_ip = msg.ip();
   if (msg.email()) ret.email = msg.email();
   if (msg.name()) ret.name = msg.name();
+
+  // Add location data
+  if (msg.context().location) ret.location_data = formatLocation(msg.context());
 
   // Add company data
   var companies = dot(traits, 'companies');
@@ -106,6 +111,53 @@ function formatCompany(company){
   var created = dot(company, 'created') || dot(company, 'created_at');
   if (created) ret.remote_created_at = created;
   return ret;
+}
+
+ /**
+ * Formats location data for use with intercom
+ *
+ * https://doc.intercom.io/api/#user-model
+ *
+ * @param {Object} location
+ * @return {Object}
+ * @api private
+ */
+
+function formatLocation(context){
+  var location = context.location || {};
+  var codes = getCountryCodes(location.country);
+
+  var ret = {
+    type: 'location_data',
+    city_name: location.city || null,
+    continent_code: codes.continent || null,
+    country_code: codes.country || null,
+    country_name: location.country || null,
+    latitude: location.latitude || null,
+    longitude: location.longitude || null,
+    region_name: location.region || null,
+    postal_code: location.postalCode || null,
+    timezone: context.timezone || null
+  };
+
+  return ret;
+}
+
+/**
+ * Gets country code.
+ *
+ * @param {Object} name
+ * @return {Object} 
+ * @api private
+ */
+
+function getCountryCodes(name){
+  if (!name) return {};
+  var codes = {};
+  var country = lookup.countries({ name: name })[0];
+  codes.country = country.alpha3;
+  codes.continent = countryList.countries[country.alpha2].continent;
+  return codes;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "batch": "^0.5.1",
+    "countries-list": "^1.0.3",
+    "country-data": "0.0.19",
     "extend": "^2.0.0",
     "is": "^2.1.0",
     "isostring": "0.0.1",

--- a/test/fixtures/identify-location.json
+++ b/test/fixtures/identify-location.json
@@ -1,0 +1,49 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe"
+    },
+    "context": {
+      "location": {
+        "city": "Dublin",
+        "country": "Ireland",
+        "latitude": 53.159233,
+        "longitude": -6.723,
+        "region": "Dublin"
+      },
+      "timezone": "Europe/Dublin"
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1388534400,
+    "remote_created_at": 1388534400,
+    "name": "john doe",
+    "custom_attributes": {
+      "created_at": 1388534400,
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id"
+    },
+    "location_data": {
+      "type": "location_data",
+      "city_name": "Dublin",
+      "continent_code": "EU",
+      "country_code": "IRL",
+      "country_name": "Ireland",
+      "latitude": 53.159233,
+      "longitude": -6.723,
+      "postal_code": null,
+      "region_name": "Dublin",
+      "timezone": "Europe/Dublin"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -97,6 +97,10 @@ describe('Intercom', function(){
       it('should map a company', function(){
         test.maps('identify-company');
       });
+
+      it('should map location', function(){
+        test.maps('identify-location');
+      });
     });
 
     describe('group', function(){


### PR DESCRIPTION
Before this PR, when users make `.identify()` calls with location data, we were mapping them all inside `custom_attributes`. But `location_data` is a semantic property for Intercom as you can see here:
https://doc.intercom.io/api/#user-model

This PR checks for `context.location` and maps it to the `location_data` specs that Intercom requires.

So users will have to send `location` information inside the `context` property when they are making `.identify()` calls. 

In response to this ticket: 
https://segment.zendesk.com/agent/tickets/27667

/cc @amillet89 @ndhoule 
