### PR TITLE
Improve success rate of messages by sending them according to the spec

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,11 +23,24 @@ var Intercom = module.exports = integration('Intercom')
   .endpoint('https://api-segment.intercom.io')
   .ensure('settings.apiKey')
   .ensure('settings.appId')
-  .ensure('message.userId')
   .channels(['server']);
 
 /**
+ * Ensure userId or email.
+ */
+
+Intercom.ensure(function(msg){
+  var email = msg.proxy('traits.email') || msg.proxy('properties.email');
+  var user = msg.userId();
+  if (!(email || user)) {
+    return this.invalid(".userId or .email is required");
+  }
+});
+
+/**
  * Identify a user in intercom
+ *
+ * https://doc.intercom.io/api/#create-or-update-user
  *
  * @param {Identify} identify
  * @param {Function} fn
@@ -35,7 +48,8 @@ var Intercom = module.exports = integration('Intercom')
  */
 
 Intercom.prototype.identify = function(identify, fn){
-  var key = [this.settings.appId, identify.userId()].join(':');
+  var id = identify.userId() || identify.email();
+  var key = [this.settings.appId, id].join(':');
   var self = this;
   this.lock(key, function(err){
     if (err) return fn(err);

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -56,7 +56,7 @@ exports.track = function(msg){
   ret.event_name = msg.event();
   ret.user_id = msg.userId();
   if (msg.email()) ret.email = msg.email();
-  ret.metadata = msg.properties();
+  ret.metadata = formatMetadata(msg.properties());
   return ret;
 };
 
@@ -109,7 +109,9 @@ function formatCompany(company){
 }
 
 /**
- * Format all the traits which are dates for intercoms format
+ * Format all the traits which are dates for intercoms format.
+ *
+ * https://doc.intercom.io/api/#custom-attributes
  *
  * @param {Object} traits
  * @return {Object}
@@ -127,6 +129,47 @@ function formatTraits(traits){
     if (is.object(val)) return ret[key] = formatTraits(val);
     if (isostring(val) || is.date(val)) return ret[dateKey(key)] = time(val);
     ret[key] = val;
+  });
+
+  return ret;
+}
+
+/**
+ * Format all the properties.
+ *
+ * https://doc.intercom.io/api/#event-metadata-types
+ *
+ * @param {Object} props
+ * @return {Object}
+ * @api private
+ */
+
+function formatMetadata(props){
+  var ret = {};
+  var safe = ['amount', 'currency', 'url', 'value'];
+
+  Object.keys(props).forEach(function(key){
+    var val = props[key];
+
+    if (is.boolean(val)) {
+      ret[key] = String(val);
+      return;
+    }
+
+    if (is.number(val) || is.string(val)) {
+      ret[key] = val;
+      return;
+    }
+    if (isostring(val) || is.date(val)) {
+      ret[dateKey(key)] = time(val);
+      return;
+    }
+
+    if (is.object(val)) {
+      if (!~safe.indexOf(Object.keys(val))) {
+        return ret[key] = time;
+      }
+    }
   });
 
   return ret;

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -16,7 +16,7 @@
     "email": "jd@example.com",
     "metadata": {
       "email": "jd@example.com",
-      "property": true
+      "property": "true"
     }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -41,34 +41,35 @@ describe('Intercom', function(){
       .endpoint('https://api-segment.intercom.io')
       .ensure('settings.apiKey')
       .ensure('settings.appId')
-      .ensure('message.userId')
       .channels(['server']);
   });
 
   describe('.validate()', function(){
-    var msg;
-
-    beforeEach(function(){
-      msg = { userId: 'user-id' };
-    });
 
     it('should be invalid if .appId is missing', function(){
       delete settings.appId;
-      test.invalid(msg, settings);
+      test.invalid({}, settings);
     });
 
     it('should be invalid if .apiKey is missing', function(){
       delete settings.apiKey;
-      test.invalid(msg, settings);
+      test.invalid({}, settings);
     });
 
-    it('should be invalid if .userId is missing', function(){
-      delete msg.userId;
-      test.invalid(msg, settings);
+    it('should be invalid if .userId and .email are missing', function(){
+      test.invalid({}, settings);
+    });
+
+    it('should be valid when just .userId is given', function(){
+      test.valid({ userId: '12345' }, settings);
+    });
+
+    it('should be valid when just .email is given', function(){
+      test.valid({ properties: { email: 'foo@bar.com' } }, settings);
     });
 
     it('should be valid when .apiKey and .appId are given', function(){
-      test.valid(msg, settings);
+      test.valid({ userId: '12345' }, settings);
     });
   });
 


### PR DESCRIPTION
See links within doc blocks for details. But to summarize:

 - require userId OR email instead of a strict requirement on userId
 - key the lock using email or userId
 - format event metadata according to the docs

Probably needs some more testing.

@sperand-io @hankim813 