### PR TITLE
add support for unsubscribing users from email'

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -19,6 +19,7 @@ var is = require('is');
 
 exports.identify = function(msg){
   var traits = formatTraits(msg.traits());
+  var context = msg.options(this.name);
   var active = msg.active();
   var ret = {};
 
@@ -32,6 +33,13 @@ exports.identify = function(msg){
   if (msg.ip()) ret.last_seen_ip = msg.ip();
   if (msg.email()) ret.email = msg.email();
   if (msg.name()) ret.name = msg.name();
+
+  // Unsubscribe user with manual flag in context.Intercom
+  // https://developers.intercom.io/docs/create-or-update-user
+  // Comparing to `undefined` since they could send `false`
+  if (context.unsubscribedFromEmails != undefined && is.boolean(context.unsubscribedFromEmails)) {
+    ret.unsubscribed_from_emails = context.unsubscribedFromEmails;
+  }
 
   // Add company data
   var companies = dot(traits, 'companies');

--- a/test/fixtures/identify-unsubscribed-from-emails.json
+++ b/test/fixtures/identify-unsubscribed-from-emails.json
@@ -1,0 +1,33 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "traits": {
+      "created": "2014-01-01",
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe"
+    },
+    "context": {
+      "Intercom": {
+        "unsubscribedFromEmails": true
+      }
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "email": "jd@example.com",
+    "last_request_at": 1388534400,
+    "remote_created_at": 1388534400,
+    "name": "john doe",
+    "unsubscribed_from_emails": true,
+    "custom_attributes": {
+      "created_at": 1388534400,
+      "email": "jd@example.com",
+      "firstName": "john",
+      "lastName": "doe",
+      "id": "user-id"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -110,6 +110,10 @@ describe('Intercom', function(){
       it('should update last_request_at with lastRequestAt when supplied', function(){
         test.maps('identify-last-request-at');
       });
+
+      it('should update unsubscribed_from_emails with unsubscribedFromEmails when supplied', function(){
+        test.maps('identify-unsubscribed-from-emails');
+      });
     });
 
     describe('group', function(){


### PR DESCRIPTION
Edited version of this #13

Moving this inside the `context.Intercom` so that it doesn't bleed into other integrations where it has no meaning by sending it as a trait. 

We will spec a context property in the future for all integrations that supports unsubscribe api. 

@sperand-io @f2prateek @bobjflong